### PR TITLE
vipper用のビルドイメージを焼く

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -32,10 +32,10 @@ jobs:
                     - { php_ver: "8.2", os_ver: "bookworm",  glibc_ver: "2.36" }
                     - { php_ver: "8.3", os_ver: "bookworm",  glibc_ver: "2.36" }
                     - { php_ver: "8.4", os_ver: "bookworm",  glibc_ver: "2.36" }
+                    - { php_ver: "8.4", os_ver: "trixie",  glibc_ver: "2.41" }
                 grpc_ver:
                     # Refarence: https://pecl.php.net/package/grpc
-                    - 1.70.0
-                    - 1.69.0
+                    - 1.75.0
 
         steps:
           - name: Checkout


### PR DESCRIPTION
## 概要

vipper の ECS 環境に合わせてビルドイメージを作成しました


## レビュー観点

* 焼いているビルドイメージが適切か
   * 参考: [バージョンについて確認した際の会話](https://eisys-group.slack.com/archives/C01HQMM9J1L/p1759908121082209?thread_ts=1757990264.651149&cid=C01HQMM9J1L)
```
=== System Information ===
PHP Version:
PHP 8.4.11 (cli) (built: Aug  3 2025 07:32:21) (NTS)
gRPC Version:
1.75.0
glibc Version:
ldd (Debian GLIBC 2.41-12) 2.41
OS Version:
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
```

* ワークフローの修正箇所が適切か.