### PR TITLE
PHP8.5に対応させるPR

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -33,6 +33,8 @@ jobs:
                     - { php_ver: "8.3", os_ver: "bookworm",  glibc_ver: "2.36" }
                     - { php_ver: "8.4", os_ver: "bookworm",  glibc_ver: "2.36" }
                     - { php_ver: "8.4", os_ver: "trixie",  glibc_ver: "2.41" }
+                    - { php_ver: "8.5", os_ver: "bookworm",  glibc_ver: "2.36" }
+                    - { php_ver: "8.5", os_ver: "trixie",  glibc_ver: "2.41" }
                 grpc_ver:
                     # Refarence: https://pecl.php.net/package/grpc
                     - 1.75.0

--- a/.github/workflows/php_server_connection_test.yml
+++ b/.github/workflows/php_server_connection_test.yml
@@ -1,5 +1,10 @@
 name: "PHP: Test gRPC Connection"
 
+# NOTE: このテストは grpc.so を自前でビルドせず、ghcr.io に publish 済みの
+#       イメージ (php<ver>-pecl-grpc<grpc_ver>-<os>) を COPY して検証します。
+#       そのため grpc_ver は "PHP: Docker Image Build" workflow と一致させ、
+#       先にビルドworkflowを実行してイメージを publish しておく必要があります。
+
 on:
     workflow_dispatch: {}
 
@@ -22,9 +27,10 @@ jobs:
                     - { php_ver: "8.2", os_ver: "bookworm",  glibc_ver: "2.36" }
                     - { php_ver: "8.3", os_ver: "bookworm",  glibc_ver: "2.36" }
                     - { php_ver: "8.4", os_ver: "bookworm",  glibc_ver: "2.36" }
+                    - { php_ver: "8.5", os_ver: "bookworm",  glibc_ver: "2.36" }
                 grpc_ver:
                     # Refarence: https://pecl.php.net/package/grpc
-                    - 1.70.0
+                    - 1.75.0
 
         steps:
           - name: Checkout

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ FROM php:8.4-fpm-bookworm
 # RUN pecl install grpc
 
 ## grpc.soを取得し、PHPの拡張モジュールディレクトリに配置します。
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.68.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.75.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && docker-php-ext-enable grpc
 ```
 
@@ -48,16 +48,18 @@ RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && docker-php-ext-enab
 
     | PHP Version Prefixes | gRPC Version Infixes | libc Environment Suffixes |
     | -------------------- | -------------------- | --------------------------|
-    | php7.3-pecl          | grpc1.69.0           | glibc2.31                 |
-    | php7.4-pecl          | grpc1.70.0           | bullseye                  |
+    | php7.3-pecl          | grpc1.75.0           | glibc2.31                 |
+    | php7.4-pecl          |                      | bullseye                  |
     | php8.0-pecl          |                      |                           |
 
     | PHP Version Prefixes | gRPC Version Infixes | libc Environment Suffixes |
     | -------------------- | -------------------- | --------------------------|
-    | php8.1-pecl          | grpc1.69.0           | glibc2.31                 |
-    | php8.2-pecl          | grpc1.70.0           | bullseye                  |
-    | php8.3-pecl          |                      | glibc2.36                 |
-    | php8.4-pecl          |                      | bookworm                  |
+    | php8.1-pecl          | grpc1.75.0           | glibc2.31                 |
+    | php8.2-pecl          |                      | glibc2.36                 |
+    | php8.3-pecl          |                      | glibc2.41                 |
+    | php8.4-pecl          |                      | bullseye                  |
+    | php8.5-pecl          |                      | bookworm                  |
+    |                      |                      | trixie                    |
 
   - Example
-    - `ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.68.0-bookworm`
+    - `ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.75.0-bookworm`

--- a/test/server-connection/docker-compose.yml
+++ b/test/server-connection/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - client
     build:
       context: .
-      dockerfile: php/php${PHP_VERSION:-8.3}-pecl-grpc${GRPC_VERSION:-1.70.0}-${OS_VERSION:-bookworm}.Dockerfile
+      dockerfile: php/php${PHP_VERSION:-8.3}-pecl-grpc${GRPC_VERSION:-1.75.0}-${OS_VERSION:-bookworm}.Dockerfile
       args:
         - PHP_BASEIMAGE_TAG=${PHP_BASEIMAGE_TAG:-8.3-fpm-bookworm}
     command: php -d extension=grpc.so -d max_execution_time=300 ./grpc/examples/php/greeter_client.php world grpc-server:50051

--- a/test/server-connection/php/php7.3-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php7.3-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -12,7 +12,7 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php7.4-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php7.3-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   ## NOTICE: peclのC実装のprotobufはPHP8.1以上が必要, そのためcomposer定義のPHP実装を利用する。
@@ -20,6 +20,6 @@ RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   # pecl install protobuf && \
   docker-php-ext-enable grpc
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php7.4-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php7.4-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -12,7 +12,7 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php7.3-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php7.4-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   ## NOTICE: peclのC実装のprotobufはPHP8.1以上が必要, そのためcomposer定義のPHP実装を利用する。
@@ -20,6 +20,6 @@ RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   # pecl install protobuf && \
   docker-php-ext-enable grpc
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.0-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php8.0-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -12,7 +12,7 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.0-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.0-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   ## NOTICE: peclのC実装のprotobufはPHP8.1以上が必要, そのためcomposer定義のPHP実装を利用する。
@@ -20,6 +20,6 @@ RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   # pecl install protobuf && \
   docker-php-ext-enable grpc
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.1-pecl-grpc1.75.0-bookworm.Dockerfile
+++ b/test/server-connection/php/php8.1-pecl-grpc1.75.0-bookworm.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.2-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.1-pecl-grpc1.75.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.1-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php8.1-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.1-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.1-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.2-pecl-grpc1.75.0-bookworm.Dockerfile
+++ b/test/server-connection/php/php8.2-pecl-grpc1.75.0-bookworm.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.70.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.2-pecl-grpc1.75.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.2-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php8.2-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.2-pecl-grpc1.70.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.2-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.3-pecl-grpc1.75.0-bookworm.Dockerfile
+++ b/test/server-connection/php/php8.3-pecl-grpc1.75.0-bookworm.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.3-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.3-pecl-grpc1.75.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.3-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php8.3-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.1-pecl-grpc1.70.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.3-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.4-pecl-grpc1.75.0-bookworm.Dockerfile
+++ b/test/server-connection/php/php8.4-pecl-grpc1.75.0-bookworm.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.70.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.75.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install

--- a/test/server-connection/php/php8.4-pecl-grpc1.75.0-bullseye.Dockerfile
+++ b/test/server-connection/php/php8.4-pecl-grpc1.75.0-bullseye.Dockerfile
@@ -1,0 +1,23 @@
+ARG PHP_BASEIMAGE_TAG
+FROM php:${PHP_BASEIMAGE_TAG}
+
+WORKDIR /work
+
+RUN apt update -y && \
+  apt install -y \
+  git \
+  build-essential \
+  autoconf \
+  zlib1g-dev
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.4-pecl-grpc1.75.0-bullseye /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+
+RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
+  pecl install protobuf && \
+  docker-php-ext-enable grpc protobuf
+
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN cd grpc/examples/php && \
+  composer install

--- a/test/server-connection/php/php8.5-pecl-grpc1.75.0-bookworm.Dockerfile
+++ b/test/server-connection/php/php8.5-pecl-grpc1.75.0-bookworm.Dockerfile
@@ -12,12 +12,12 @@ RUN apt update -y && \
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.3-pecl-grpc1.70.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
+COPY --from=ghcr.io/vivion-inc/grpc-docker:php8.5-pecl-grpc1.75.0-bookworm /usr/local/lib/php/extensions/grpc.so /tmp/grpc.so
 
 RUN mv /tmp/grpc.so $(php-config --extension-dir)/grpc.so && \
   pecl install protobuf && \
   docker-php-ext-enable grpc protobuf
 
-RUN git clone --recurse-submodules -b v1.70.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+RUN git clone --recurse-submodules -b v1.75.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
 RUN cd grpc/examples/php && \
   composer install


### PR DESCRIPTION
概要
ミステリーラボがPHP8.5-fpmのイメージを使っており、決済MSに接続したいため

チケット情報
https://vivion.atlassian.net/browse/QFAN-4903

チケット変更箇所
1. PHP 8.5 追加
- image_build.yml：8.5 / bookworm(glibc2.36) 8.5 / trixie(glibc2.41) を追加
- php_server_connection_test.yml：8.5 / bookworm を追加
- README タグ表に php8.5-pecl・trixie・glibc2.41 を補記

2. gRPC版の統一（テスト ↔ ビルド = 1.75.0）
- php_server_connection_test.yml：grpc_ver を 1.70.0 → 1.75.0
- テスト用Dockerfile 全12種を grpc1.70.0 → grpc1.75.0 にリネーム＋中身（COPY --from タグ・git clone -b v...）を更新
- docker-compose.yml：デフォルト GRPC_VERSION を 1.70.0 → 1.75.0
- README の gRPC版表記・サンプルを 1.75.0 に更新

3. 実行順序の明文化
- テストworkflow冒頭に「publish済みイメージを参照するため、先にビルドworkflowを実行する必要がある」旨のコメントを追加