### PR TITLE
fix: PHP 8.5 (trixie) で grpc 拡張のビルドが失敗する問題を修正

### DIFF
--- a/src/php/glibc/debian.Dockerfile
+++ b/src/php/glibc/debian.Dockerfile
@@ -13,7 +13,14 @@ RUN apt update -y && \
 ARG GRPC_VERSION
 ARG GRPC_OUTPUT_PATH
 
+# NOTE: grpc-1.75.0 のソース (src/php/ext/grpc/call.c) は PHP 8.5 で
+# ヘッダ宣言が無くなった zend_exception_get_default() を使用している。
+# Debian trixie の GCC 14+ では -Wimplicit-function-declaration /
+# -Wint-conversion がデフォルトでエラーに昇格するためビルドが失敗する
+# (bookworm の GCC 12 では警告止まりで通る)。上流 grpc 側の非互換を
+# 回避するため、当該診断を警告に戻してビルドを通す。
 RUN MAKEFLAGS="-j $(nproc)" \
+    CFLAGS="-Wno-implicit-function-declaration -Wno-int-conversion" \
     pecl install grpc-${GRPC_VERSION}
 
 RUN strip --strip-all $(php-config --extension-dir)/grpc.so && \


### PR DESCRIPTION
## 概要

`PHP: Docker Image Build` ワークフロー (run [28357565984](https://github.com/viviON-inc/grpc-docker/actions/runs/28357565984)) で `php-debian (8.5, trixie, 2.41, 1.75.0)` ジョブの Image Build が失敗していた問題を修正します。

## 原因

grpc-1.75.0 のソース `src/php/ext/grpc/call.c` が、PHP 8.5 でヘッダ宣言が無くなった `zend_exception_get_default()` を使用しています（上流 grpc 側の PHP 8.5 非互換）。

```
src/php/ext/grpc/call.c:87:30: error: implicit declaration of function
  'zend_exception_get_default'; did you mean 'zend_exception_set_previous'?
make: *** [Makefile:2926: src/php/ext/grpc/call.lo] Error 1
```

- **bookworm (GCC 12):** 暗黙宣言は *警告* 止まりでビルドが通る → 8.5/bookworm は成功していた
- **trixie (GCC 14+):** C99 準拠の厳格化により `-Wimplicit-function-declaration` / `-Wint-conversion` が *デフォルトでエラー* に昇格 → ハードエラーで停止

## 変更内容

`pecl install` 時の `CFLAGS` で当該診断を警告に戻し、bookworm と同じ挙動でビルドを通します。

```dockerfile
RUN MAKEFLAGS="-j $(nproc)" \
    CFLAGS="-Wno-implicit-function-declaration -Wno-int-conversion" \
    pecl install grpc-${GRPC_VERSION}
```

## 補足 / 残課題

- これは上流 grpc の PHP 8.5 非互換に対する **回避策** です。当該関数が PHP 8.5 バイナリにシンボルとして存在する前提で成立しています（bookworm/GCC12 で実際にリンク・成功している実績あり）。
- 根本対応としては、`zend_exception_get_default` 問題を解消した新しい grpc バージョンへの更新が望ましいです。
- ビルド成功後、trixie 環境で生成された `grpc.so` が実際にロード・動作するかの検証を推奨します。
- なお同 run の `php-debian (8.3, bookworm)` の失敗は Docker Hub への接続タイムアウト（一過性のインフラ障害）であり、本PRの対象外です（再実行で解消見込み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)